### PR TITLE
Two Typo's

### DIFF
--- a/tex_files/expdistribution.tex
+++ b/tex_files/expdistribution.tex
@@ -20,7 +20,7 @@ an \recall{exponentially distributed} random variable, i.e.,
   \P{X \leq t} = 1- e^{-\lambda t}
 \end{equation*}
 Moreover,  the exponential distribution  derives directly from the Poisson distribution. Observe that, if there are no arrivals in some interval $[0,t]$, then it
-must be that $N(t) = 0$. Hence, the first inter-arrival time $X$, i.e., the time until the first customer,  must be larger than $t$.  Therefore,
+must be that $N(t) = 0$. Hence, the first inter-arrival time $X_1$, i.e., the time until the first customer,  must be larger than $t$.  Therefore,
 \begin{equation*}
  \P{X_1> t} = \P{N(t) = 0} = e^{-\lambda t} \frac{(\lambda t)^0}{0!}= e^{-\lambda t}.
 \end{equation*}


### PR DESCRIPTION
Removed "In" in: "In the previous section we introduced the Poisson process as a natural model of the number of jobs arriving in during intervals of time." 

Added subscript to first inter-arrival time in: "Hence, the first inter-arrival time $X$, i.e., the time until the first customer,  must be larger than $t$.  Therefore,..."